### PR TITLE
Global document query cache

### DIFF
--- a/src/Document.php
+++ b/src/Document.php
@@ -146,7 +146,7 @@ abstract class Document implements ArrayAccess
 
     public function newQuery(): Query
     {
-        return (new Query)->type($this->getType());
+        return Query::make()->type($this->getType());
     }
 
     public function getMaps()

--- a/src/DocumentResolver.php
+++ b/src/DocumentResolver.php
@@ -8,13 +8,13 @@ class DocumentResolver
 {
     public function resolve($item): ?Document
     {
-        return (new Query)->find(data_get($item, 'id'));
+        return Query::make()->find(data_get($item, 'id'));
     }
 
     public function resolveMany($items): Collection
     {
         $ids = collect($items)->pluck('id')->filter()->toArray();
 
-        return (new Query)->findMany($ids);
+        return Query::make()->findMany($ids);
     }
 }

--- a/src/Fields/Link.php
+++ b/src/Fields/Link.php
@@ -21,7 +21,9 @@ abstract class Link implements Htmlable
 
     public static function resolveMany($items): Collection
     {
-        return resolve(LinkResolver::class)->resolveMany($items);
+        return collect($items)->map(function($item) {
+            return $this->resolve($item);
+        });
     }
 
     public static function make(...$parameters): Link

--- a/src/Fields/Link.php
+++ b/src/Fields/Link.php
@@ -19,13 +19,6 @@ abstract class Link implements Htmlable
         return resolve(LinkResolver::class)->resolve(...$parameters);
     }
 
-    public static function resolveMany($items): Collection
-    {
-        return collect($items)->map(function($item) {
-            return $this->resolve($item);
-        });
-    }
-
     public static function make(...$parameters): Link
     {
         return new static(...$parameters);

--- a/src/Fields/LinkResolver.php
+++ b/src/Fields/LinkResolver.php
@@ -14,55 +14,6 @@ class LinkResolver
         return method_exists($this, $method) ? $this->{$method}($item, $title) : null;
     }
 
-    public function resolveMany($items): Collection
-    {
-        $items = collect($items)
-            ->reject(function ($item) {
-                $linkType = data_get($item, '0.link_type');
-                $id = data_get($item, '0.id');
-
-                return (bool) ($linkType == 'Document' && ! $id) || $linkType == 'Any';
-            })
-            ->map(function ($item, $key) {
-                $item['order'] = $key;
-
-                return $item;
-            });
-
-        $order = $items->pluck('order')->toArray();
-        $items = $items->groupBy('0.link_type');
-        $links = collect();
-
-        if (isset($items['Document'])) {
-            $links = $links->merge(
-                $this->makeDocumentLinks($items['Document'])
-            );
-
-            unset($items['Document']);
-        }
-
-        $items = $items->collapse();
-
-        foreach ($items as $key => $item) {
-            $link = $this->resolve($item[0], $item[1]);
-            $link->order = $item['order'];
-            $links->push($link);
-        }
-
-        $links = $links
-            ->sortBy(function ($link) use ($order) {
-                return array_search($link->order, $order);
-            })
-            ->map(function ($link) {
-                unset($link->order);
-
-                return $link;
-            })
-            ->values();
-
-        return $links;
-    }
-
     protected function makeWebLink($item, $title)
     {
         return WebLink::make(data_get($item, 'url'), $title)
@@ -83,20 +34,5 @@ class LinkResolver
         }
 
         return DocumentLink::make($document, $title);
-    }
-
-    protected function makeDocumentLinks($items)
-    {
-        $titles = $items->pluck(1, '0.id');
-        $order = $items->pluck('order', '0.id');
-
-        return resolve(DocumentResolver::class)
-            ->resolveMany($items->pluck(0))
-            ->map(function ($document) use ($titles, $order) {
-                $link = DocumentLink::make($document, data_get($titles, $document->id));
-                $link->order = data_get($order, $document->id);
-
-                return $link;
-            });
     }
 }

--- a/src/Query.php
+++ b/src/Query.php
@@ -15,7 +15,7 @@ class Query
     protected $type;
     protected $wheres = [];
     protected $options = [];
-    protected $cacheQueryResults = false;
+    protected $shouldCache = false;
     protected static $allDocumentsCached = false;
     protected static $cachedDocuments = [];
 
@@ -58,21 +58,16 @@ class Query
 
     public function cache(): Query
     {
-        $this->cacheQueryResults = true;
+        $this->shouldCache = true;
 
         return $this;
     }
 
     public function dontCache(): Query
     {
-        $this->cacheQueryResults = false;
+        $this->shouldCache = false;
 
         return $this;
-    }
-
-    public function shouldCache(): bool
-    {
-        return $this->cacheQueryResults;
     }
 
     public function type($type): Query
@@ -156,7 +151,7 @@ class Query
     {
         $records = $this->hydrateDocuments(array_shift($this->getRaw()->results));
 
-        return $this->shouldCache() ? static::addToDocumentCache($records)->first() : $records->first();
+        return $this->shouldCache ? static::addToDocumentCache($records)->first() : $records->first();
     }
 
     public function chunk($pageSize, callable $callback)
@@ -172,7 +167,7 @@ class Query
             $results = $this->hydrateDocuments($response->results);
 
             $callback(
-                $this->shouldCache() ? static::addToDocumentCache($results) : $results
+                $this->shouldCache ? static::addToDocumentCache($results) : $results
             );
         } while ($page++ < $response->total_pages);
     }

--- a/src/Query.php
+++ b/src/Query.php
@@ -98,7 +98,7 @@ class Query
             return collect();
         }
 
-        if (($results = static::recordCache()->only($ids)) && count($ids) === $results->count()) {
+        if (($results = static::recordCache()->only($ids)->values()) && count($ids) === $results->count()) {
             return $results;
         }
 

--- a/src/Query.php
+++ b/src/Query.php
@@ -15,11 +15,15 @@ class Query
     protected $wheres = [];
     protected $options = [];
     protected $cacheQueryResults = false;
+    protected static $allRecordsCached = false;
     protected static $cachedRecords = [];
 
     public static function eagerLoadAll(): Query
     {
-        (new static)->cache()->get();
+        if ( ! static::$allRecordsCached) {
+            (new static)->cache()->get();
+            static::$allRecordsCached = true;
+        }
 
         return new static;
     }

--- a/src/Traversable.php
+++ b/src/Traversable.php
@@ -16,6 +16,6 @@ trait Traversable
 
     public function traverse()
     {
-        return (new Traverser($this->id));
+        return (new Traverser($this));
     }
 }

--- a/src/Traverser.php
+++ b/src/Traverser.php
@@ -76,7 +76,7 @@ class Traverser
 
     protected function getParentFromChildren(): ?Document
     {
-        return $this->query->recordCache()->first(function ($document) {
+        return $this->query->documentCache()->first(function ($document) {
             $childrenMethod = $this->getChildrenMethod($document);
 
             if (method_exists($document, $childrenMethod)) {
@@ -136,7 +136,7 @@ class Traverser
         if ($parent = $this->document->{$parentMethod}()) {
             $ancestors->prepend($parent->id);
 
-            $ancestors = $parent->traverse()->getAncestors()->merge($ancestors);
+            $ancestors = (new static($parent))->getAncestors()->merge($ancestors);
         }
 
         return $ancestors;

--- a/src/Traverser.php
+++ b/src/Traverser.php
@@ -6,17 +6,18 @@ use Illuminate\Support\Collection;
 
 class Traverser
 {
-    protected static $documents;
-
-    protected $id;
+    protected $query;
+    protected $document;
     protected $parentId;
     protected $childrenIds;
     protected $parentMethods;
     protected $childrenMethods;
 
-    public function __construct($id)
+    public function __construct($document)
     {
-        $this->id = $id;
+        $this->document = $document;
+
+        $this->query = Query::eagerLoadAll();
 
         $this->parentMethods = collect(
             array_fill_keys(Prismic::$documents, 'parent')
@@ -70,19 +71,19 @@ class Traverser
 
     protected function getParentFromId(): ?Document
     {
-        return static::getDocuments()->get($this->parentId);
+        return $this->query->find($this->parentId);
     }
 
     protected function getParentFromChildren(): ?Document
     {
-        return static::getDocuments()->first(function ($document) {
+        return $this->query->recordCache()->first(function ($document) {
             $childrenMethod = $this->getChildrenMethod($document);
 
             if (method_exists($document, $childrenMethod)) {
                 return $document->{$childrenMethod}()
                     ->filter()
                     ->first(function ($document) {
-                        return $document->id == $this->id;
+                        return $document->id == $this->document->id;
                     });
             }
         });
@@ -103,8 +104,8 @@ class Traverser
 
     protected function getChildrenFromIds(): Collection
     {
-        return $this->childrenIds->map(function ($id) {
-            return static::getDocuments()->get($id);
+        return $this->childrenIds->map(function($id) {
+            return $this->query->find($id);
         });
     }
 
@@ -116,29 +117,26 @@ class Traverser
 
     public function ancestors(): Collection
     {
-        return $this->getAncestors(
-            $this->getDocuments()->get($this->id)
-        );
+        return $this->getAncestors()->map(function($id) {
+            return $this->query->find($id);
+        });
     }
 
     public function ancestorsAndSelf(): Collection
     {
-        return $this->ancestors()->push(
-            $this->getDocuments()->get($this->id)
-        );
+        return $this->ancestors()->push($this->document);
     }
 
-    protected function getAncestors(Document $document, $ancestors = null): Collection
+    protected function getAncestors(): Collection
     {
-        if ( ! $ancestors instanceof Collection) {
-            $ancestors = collect();
-        }
+        $ancestors = collect();
 
-        $parentMethod = $this->getParentMethod($document);
+        $parentMethod = $this->getParentMethod($this->document);
 
-        if ($parent = $document->{$parentMethod}()) {
-            $ancestors->prepend($parent);
-            $this->getAncestors($parent, $ancestors);
+        if ($parent = $this->document->{$parentMethod}()) {
+            $ancestors->prepend($parent->id);
+
+            $ancestors = $parent->traverse()->getAncestors()->merge($ancestors);
         }
 
         return $ancestors;
@@ -146,30 +144,27 @@ class Traverser
 
     public function descendants(): Collection
     {
-        return $this->getDescendants(
-            $this->getDocuments()->get($this->id)
-        );
+        return $this->getDescendants()->map(function($id) {
+            return $this->query->find($id);
+        });
     }
 
     public function descendantsAndSelf(): Collection
     {
-        return $this->descendants()->prepend(
-            $this->getDocuments()->get($this->id)
-        );
+        return $this->descendants()->prepend($this->document);
     }
 
-    protected function getDescendants(Document $document, $descendants = null): Collection
+    protected function getDescendants(): Collection
     {
-        if ( ! $descendants instanceof Collection) {
-            $descendants = collect();
-        }
+        $descendants = collect();
 
-        $childrenMethod = $this->getChildrenMethod($document);
+        $childrenMethod = $this->getChildrenMethod($this->document);
 
-        if ($children = $document->{$childrenMethod}()) {
+        if ($children = $this->document->{$childrenMethod}()) {
             foreach ($children as $child) {
-                $descendants->push($child);
-                $this->getDescendants($child, $descendants);
+                $descendants = $descendants
+                    ->push($child->id)
+                    ->merge($child->traverse()->getDescendants());
             }
         }
 
@@ -179,7 +174,7 @@ class Traverser
     public function siblings(): Collection
     {
         return $this->siblingsAndSelf()->reject(function ($document) {
-            return $document->id == $this->id;
+            return $document->id == $this->document->id;
         });
     }
 
@@ -200,14 +195,5 @@ class Traverser
     protected function getChildrenMethod(Document $document)
     {
         return $this->childrenMethods->get(get_class($document));
-    }
-
-    protected static function getDocuments(): Collection
-    {
-        if ( ! static::$documents) {
-            static::$documents = (new Query)->get()->keyBy('id');
-        }
-
-        return static::$documents;
     }
 }

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -96,9 +96,9 @@ class QueryTest extends TestCase
 
     public function test_first()
     {
-        $query = m::mock(Query::class . '[get]');
+        $query = m::mock(Query::class . '[getRaw]');
         $collection = m::mock(Collection::class . '[first]');
-        $query->shouldReceive('get')->once()->andReturn($collection);
+        $query->shouldReceive('getRaw')->once()->andReturn((object) ['results' => []]);
         $collection->shouldReceive('first');
         $query->first();
     }
@@ -115,17 +115,19 @@ class QueryTest extends TestCase
         $query->shouldReceive('getRaw')->times(3)->andReturn($responseStub);
 
         $count = 0;
-
         $query->chunk(100, function ($chunk) use (&$count) {
             $count++;
             $this->assertInstanceOf(Collection::class, $chunk);
         });
 
         $this->assertEquals(3, $count);
+    }
 
+    public function test_chunk_exceeding_chunk_limit()
+    {
         $this->expectException(InvalidArgumentException::class);
 
-        $query->chunk(101, function () {
+        (new Query)->chunk(101, function () {
             // do nothing
         });
     }


### PR DESCRIPTION
There are often many places in the code that require the resolution of documents via `Query::find` and `Query::findMany` which could lead to many n+1 issues with each one performing a query to the Prismic API.

This provides a pretty simply caching mechanism that either allows for `Query::eagerLoadAll()` to be run, or for the chaining of the `cache()` method on a particular query: `(new Query)->type('article')->cache()->get()`