### PR TITLE
Add ability to shift heading levels

### DIFF
--- a/src/Fields/RichText.php
+++ b/src/Fields/RichText.php
@@ -141,18 +141,14 @@ class RichText implements Htmlable
 
     public function shiftHeadings(int $shiftBy)
     {
-        if ($this->htmlSerializer) {
-            $this->htmlSerializer->shiftHeadings($shiftBy);
-        }
+        $this->htmlSerializer->shiftHeadings($shiftBy);
 
         return $this;
     }
 
     public function inlineOnly($inlineOnly = true)
     {
-        if ($this->htmlSerializer) {
-            $this->htmlSerializer->inlineOnly($inlineOnly);
-        }
+        $this->htmlSerializer->inlineOnly($inlineOnly);
 
         return $this;
     }

--- a/src/Fields/RichText.php
+++ b/src/Fields/RichText.php
@@ -139,6 +139,15 @@ class RichText implements Htmlable
         return $this;
     }
 
+    public function shiftHeadings(int $shiftBy)
+    {
+        if ($this->htmlSerializer) {
+            $this->htmlSerializer->shiftHeadings($shiftBy);
+        }
+
+        return $this;
+    }
+
     public function inlineOnly($inlineOnly = true)
     {
         if ($this->htmlSerializer) {

--- a/src/Fields/RichTextHtmlSerializer.php
+++ b/src/Fields/RichTextHtmlSerializer.php
@@ -33,14 +33,12 @@ class RichTextHtmlSerializer implements Contract
 
     public function serialize($element, $content): string
     {
-        $type = $element->type;
-
-        if ($this->inlineOnly && ! $this->isInlineElement($type)) {
+        if ($this->inlineOnly && ! $this->isInlineElement($element->type)) {
             return $content;
         }
 
-        if ($this->shiftHeadings && Str::startsWith($type, 'heading')) {
-            $newHeadingLevel = (int) (str_replace('heading', '', $type) + $this->shiftHeadings);
+        if ($this->shiftHeadings && Str::startsWith($element->type, 'heading')) {
+            $newHeadingLevel = str_replace('heading', '', $element->type) + $this->shiftHeadings;
 
             if ($newHeadingLevel < 1) {
                 $newHeadingLevel = 1;
@@ -48,16 +46,14 @@ class RichTextHtmlSerializer implements Contract
                 $newHeadingLevel = 6;
             }
 
-            $element->type = 'heading' . (int) $newHeadingLevel;
-
-            return (clone $this)->shiftHeadings(0)->serialize($element, $content);
+            $element->type = "heading$newHeadingLevel";
         }
 
-        if ($this->hasSerializerFor($type)) {
-            return call_user_func($this->getSerializerFor($type), $element, $content);
+        if ($this->hasSerializerFor($element->type)) {
+            return call_user_func($this->getSerializerFor($element->type), $element, $content);
         }
 
-        $localMethod = 'serialize'.Str::studly($type);
+        $localMethod = 'serialize'.Str::studly($element->type);
         if (method_exists($this, $localMethod)) {
             return $this->$localMethod($element, $content);
         }

--- a/tests/RichTextHtmlSerializerTest.php
+++ b/tests/RichTextHtmlSerializerTest.php
@@ -137,4 +137,55 @@ class RichTextHtmlSerializerTest extends TestCase
         $this->assertEquals('<p>Look at <a href="#past-papers">past papers</a>, so you know what to expect.</p>', $richtext->toHtml());
         $this->assertEquals('Look at past papers, so you know what to expect.', $richtext->asText());
     }
+
+    public function test_heading_shifts()
+    {
+        $richtext = RichText::make([(object) [
+            "type" => "heading3",
+            "text" => "Heading 3 now 2",
+            "spans" => [],
+        ]])
+        ->setHtmlSerializer(
+            (new RichTextHtmlSerializer)->shiftHeadings(-1)
+        );
+
+        $this->assertEquals('<h2>Heading 3 now 2</h2>', $richtext->toHtml());
+        $this->assertEquals('Heading 3 now 2', $richtext->asText());
+
+        $richtext = RichText::make([(object) [
+            "type" => "heading3",
+            "text" => "Heading 3 now 4",
+            "spans" => [],
+        ]])
+        ->setHtmlSerializer(
+            (new RichTextHtmlSerializer)->shiftHeadings(1)
+        );
+
+        $this->assertEquals('<h4>Heading 3 now 4</h4>', $richtext->toHtml());
+        $this->assertEquals('Heading 3 now 4', $richtext->asText());
+
+        $richtext = RichText::make([(object) [
+            "type" => "heading3",
+            "text" => "Heading 3 now 1",
+            "spans" => [],
+        ]])
+        ->setHtmlSerializer(
+            (new RichTextHtmlSerializer)->shiftHeadings(-5)
+        );
+
+        $this->assertEquals('<h1>Heading 3 now 1</h1>', $richtext->toHtml());
+        $this->assertEquals('Heading 3 now 1', $richtext->asText());
+
+        $richtext = RichText::make([(object) [
+            "type" => "heading3",
+            "text" => "Heading 3 now 6",
+            "spans" => [],
+        ]])
+        ->setHtmlSerializer(
+            (new RichTextHtmlSerializer)->shiftHeadings(5)
+        );
+
+        $this->assertEquals('<h6>Heading 3 now 6</h6>', $richtext->toHtml());
+        $this->assertEquals('Heading 3 now 6', $richtext->asText());
+    }
 }


### PR DESCRIPTION
Adds the ability to shift headings up and down, useful when rendering content in different contexts.

Some thoughts:

- Would it be useful to have a `decreaseHeading()` and `increaseHeading()` alias?
_I would probably add this to the RichText implementation_
- Would it be useful to target specific headings